### PR TITLE
Fixup the send-debug-broadcast script, and update example listener

### DIFF
--- a/listeners/examples/doorbot-listener-example.py
+++ b/listeners/examples/doorbot-listener-example.py
@@ -15,8 +15,10 @@ class ExampleListener(DoorbotListener.DoorbotListener):
         print "Door opened by %s, card serial %s." % (name, serial)
 
     def unknownCard(self, serial):
-        print "Unknown card %s presented at the door." %s serial
+        print "Unknown card %s presented at the door." % (serial)
 
+    def trigger(self, filename):
+        print "Audio file [%s] triggered." % (filename)
 
 listener = ExampleListener()
 listener.listen()

--- a/listeners/send-debug-broadcast.py
+++ b/listeners/send-debug-broadcast.py
@@ -2,13 +2,42 @@
 import sys
 from socket import *
 
-if (sys.argv[1] not in ('BELL', 'RFID')):
-    print "Unknown event type, valid types are (RFID, BELL)"
-    sys.exit(0)
+def usage():
+    """ Print some usage info """
+    print "Usage: " + sys.argv[0] + " [BELL|RFID|TRIGGER]"
+
+if len(sys.argv) < 2:
+    usage()
+    sys.exit(1)
+
+cmd = sys.argv[1].upper()
+if cmd == "BELL":
+        print "Ringing the doorbell..."
+        data = "BELL\n\n"
+elif cmd == "RFID":
+        if len(sys.argv) != 4:
+            print "Usage: %s RFID [name] [cardid]" % (sys.argv[0])
+            sys.exit(1)
+        # do RFID stuff
+        name   = sys.argv[2]
+        cardid = sys.argv[3]
+        print "Pretending user [%s] with cardid [%s] presented their card" % (name, cardid)
+        data = "RFID\n%s\n%s" % (cardid, name)
+elif cmd == "TRIGGER":
+        if len(sys.argv) != 3:
+            print "Usage: %s TRIGGER [filename]" % (sys.argv[0])
+            sys.exit(1)
+        # Trigger an audio file
+        filename = sys.argv[2]
+        print "Triggering audio file [%s]" % (filename)
+        data = "TRIGGER\n%s\n" % (filename)
+else:
+        print "Unknown command [%s]" % (cmd)
+        usage()
+        sys.exit(1)
 
 s = socket(AF_INET, SOCK_DGRAM)
 s.bind(('', 0))
 s.setsockopt(SOL_SOCKET, SO_BROADCAST, 1)
 
-data = "\n".join(sys.argv[1:])
 s.sendto(data, ('<broadcast>', 50000))


### PR DESCRIPTION
The send-debug-broadcast script was very non-intuitive. Make it more user friendly.

Update the example listener to listen for trigger events (for playing audio files).
