### PR TITLE
Non-subscribers should not return a name

### DIFF
--- a/listeners/carddb.py
+++ b/listeners/carddb.py
@@ -9,7 +9,7 @@ class CardDB:
     def nickForCard(self, card_serial):
         self.maybeRefresh()
         for entry in self.db:
-            if card_serial in entry['cards']:
+            if card_serial in entry['cards'] and entry['subscribed'] == True:
                 return entry['nick']
         return None
 


### PR DESCRIPTION
This is the expected behaviour and why IRC notifications are wrong. Now they will not be wrong.
